### PR TITLE
Fixed Blueprint

### DIFF
--- a/Source/Live2DCubismFramework/Private/Effects/EyeBlink/CubismEyeBlinkComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Effects/EyeBlink/CubismEyeBlinkComponent.cpp
@@ -52,14 +52,27 @@ void UCubismEyeBlinkComponent::Setup(UCubismModelComponent* InModel)
 	Model->AddTickPrerequisiteComponent(this); // model ticks after parameters are updated by components
 }
 
+TObjectPtr<UCubismModelComponent> UCubismEyeBlinkComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismEyeBlinkComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -118,9 +131,12 @@ void UCubismEyeBlinkComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismEyeBlinkComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)

--- a/Source/Live2DCubismFramework/Private/Effects/HarmonicMotion/CubismHarmonicMotionComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Effects/HarmonicMotion/CubismHarmonicMotionComponent.cpp
@@ -41,14 +41,27 @@ void UCubismHarmonicMotionComponent::Setup(UCubismModelComponent* InModel)
 	Model->AddTickPrerequisiteComponent(this); // model ticks after parameters are updated by components
 }
 
+TObjectPtr<UCubismModelComponent> UCubismHarmonicMotionComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismHarmonicMotionComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UObject interface
 
@@ -57,9 +70,12 @@ void UCubismHarmonicMotionComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismHarmonicMotionComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)

--- a/Source/Live2DCubismFramework/Private/Effects/LipSync/CubismLipSyncComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Effects/LipSync/CubismLipSyncComponent.cpp
@@ -119,14 +119,27 @@ TObjectPtr<UAudioComponent> UCubismLipSyncComponent::CreateAudioComponent()
 	return NewAudio;
 }
 
+TObjectPtr<UCubismModelComponent> UCubismLipSyncComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismLipSyncComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -199,9 +212,12 @@ void UCubismLipSyncComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismLipSyncComponent::OnComponentDestroyed(bool bDestroyingHierarchy)

--- a/Source/Live2DCubismFramework/Private/Effects/LookAt/CubismLookAtComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Effects/LookAt/CubismLookAtComponent.cpp
@@ -44,14 +44,27 @@ void UCubismLookAtComponent::Setup(UCubismModelComponent* InModel)
 	Model->AddTickPrerequisiteComponent(this); // model ticks after parameters are updated by components
 }
 
+TObjectPtr<UCubismModelComponent> UCubismLookAtComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismLookAtComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UObject interface
 
@@ -60,9 +73,12 @@ void UCubismLookAtComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismLookAtComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)

--- a/Source/Live2DCubismFramework/Private/Effects/Raycast/CubismRaycastComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Effects/Raycast/CubismRaycastComponent.cpp
@@ -224,14 +224,27 @@ bool UCubismRaycastComponent::RayIntersectTriangle
 	return true;
 }
 
+TObjectPtr<UCubismModelComponent> UCubismRaycastComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismRaycastComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UObject interface
 
@@ -240,8 +253,11 @@ void UCubismRaycastComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UActorComponent interface

--- a/Source/Live2DCubismFramework/Private/Expression/CubismExpressionComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Expression/CubismExpressionComponent.cpp
@@ -82,14 +82,28 @@ void UCubismExpressionComponent::StopAllExpressions(const bool bForce)
 	}
 }
 
+TObjectPtr<UCubismModelComponent> UCubismExpressionComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
+
 // UObject interface
 void UCubismExpressionComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -119,9 +133,12 @@ void UCubismExpressionComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismExpressionComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)

--- a/Source/Live2DCubismFramework/Private/Model/CubismDrawableComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Model/CubismDrawableComponent.cpp
@@ -187,14 +187,27 @@ int32 UCubismDrawableComponent::GetDrawableMaskCount() const
 	return Model->GetDrawableMaskCount(Index);
 }
 
+TObjectPtr<UCubismModelComponent> UCubismDrawableComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismDrawableComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -269,9 +282,12 @@ void UCubismDrawableComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismDrawableComponent::SendRenderDynamicData_Concurrent()

--- a/Source/Live2DCubismFramework/Private/Model/CubismModelComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Model/CubismModelComponent.cpp
@@ -13,6 +13,12 @@
 #include "Model/CubismParameterComponent.h"
 #include "Model/CubismPartComponent.h"
 #include "UserData/CubismUserData3Json.h"
+#include "Model/CubismParameterStoreComponent.h"
+#include "Rendering/CubismRendererComponent.h"
+#include "Pose/CubismPoseComponent.h"
+#include "Motion/CubismMotionComponent.h"
+#include "Expression/CubismExpressionComponent.h"
+#include "Physics/CubismPhysicsComponent.h"
 
 #include "CubismLog.h"
 
@@ -29,6 +35,12 @@ UCubismModelComponent::~UCubismModelComponent()
 
 void UCubismModelComponent::Setup()
 {
+
+	if (!Moc)
+	{
+		return;
+	}
+
 	check(Moc);
 
 	Moc->SetupModel(this);
@@ -564,9 +576,20 @@ void UCubismModelComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
+	if (!Moc)
+	{
+		return;
+	}
+
 	check(Moc);
 
 	Moc->SetupModel(this);
+
+	//Need to ensure that the model is cleaned up before it can be created
+	if (NonNativeParameterIds.Num() > 0)
+	{
+		ComponentCleanup();
+	}
 
 	{
 		const int32 DrawableCount = csmGetDrawableCount(RawModel);
@@ -626,12 +649,97 @@ void UCubismModelComponent::OnComponentCreated()
 			Parts.Add(Part);
 		}
 	}
+
+	Setup();
+	ComponentSetup();
 }
 
-void UCubismModelComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
+void UCubismModelComponent::ComponentSetup()
+{
+	//Setting up the Store Component
+	if (!ParameterStore)
+	{
+		ParameterStore = NewObject<UCubismParameterStoreComponent>(this, UCubismParameterStoreComponent::StaticClass());
+		ParameterStore->RegisterComponent();
+	}
+	
+
+	//Setting up the renderer Component
+	if (!Renderer)
+	{
+		Renderer = NewObject<UCubismRendererComponent>(this, UCubismRendererComponent::StaticClass());
+		Renderer->RegisterComponent();
+	}
+	
+
+	//Setting up the pose component
+	if (!Pose)
+	{
+		Pose = NewObject<UCubismPoseComponent>(this, UCubismPoseComponent::StaticClass());
+		if (PoseJson)
+		{
+			Pose->Json = PoseJson;
+		}
+		Pose->RegisterComponent();
+	}
+
+
+	//Setting up the motion component
+	if (!Motion)
+	{
+		Motion = NewObject<UCubismMotionComponent>(this, UCubismMotionComponent::StaticClass());
+
+		if (MotionJsons.Num() > 0)
+		{
+			Motion->Jsons = MotionJsons;
+		}
+
+		Motion->RegisterComponent();
+
+		if (MotionJsons.Num() > 0)
+		{
+			if (MotionJsons[0])
+			{
+				Motion->PlayMotion(0, 0.0f, ECubismMotionPriority::Idle);
+			}
+		}
+	}
+
+	//Setting up the expression component
+	if (!Expression)
+	{
+		Expression = NewObject<UCubismExpressionComponent>(this, UCubismExpressionComponent::StaticClass());
+
+		if (ExpressionJsons.Num() > 0)
+		{
+			Expression->Jsons = ExpressionJsons;
+		}
+
+		Expression->RegisterComponent();
+	}
+
+	//Setting up the physics component
+	if (!Physics)
+	{
+		Physics = NewObject<UCubismPhysicsComponent>(this, UCubismPhysicsComponent::StaticClass());
+
+		if (PhysicsJson)
+		{
+			Physics->Json = PhysicsJson;
+		}
+
+		Physics->RegisterComponent();
+	}
+}
+
+void UCubismModelComponent::ComponentCleanup() 
 {
 	for (const TObjectPtr<UCubismDrawableComponent>& Drawable : Drawables)
 	{
+		if (!Drawable)
+		{
+			continue;
+		}
 		Drawable->DetachFromComponent(FDetachmentTransformRules::KeepRelativeTransform);
 		GetOwner()->RemoveInstanceComponent(Drawable);
 		Drawable->DestroyComponent();
@@ -639,11 +747,19 @@ void UCubismModelComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 
 	for (const TObjectPtr<UCubismParameterComponent>& Parameter : Parameters)
 	{
+		if (!Parameter)
+		{
+			continue;
+		}
 		Parameter->DestroyComponent();
 	}
 
 	for (const TObjectPtr<UCubismPartComponent>& Part : Parts)
 	{
+		if (!Part)
+		{
+			continue;
+		}
 		Part->DestroyComponent();
 	}
 
@@ -654,6 +770,12 @@ void UCubismModelComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 	DrawableIndices.Empty();
 	ParameterIndices.Empty();
 	PartIndices.Empty();
+	NonNativeParameterIds.Empty();
+}
+
+void UCubismModelComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
+{
+	ComponentCleanup();
 
 	Moc->DeleteModel(this);
 

--- a/Source/Live2DCubismFramework/Private/Model/CubismParameterComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Model/CubismParameterComponent.cpp
@@ -98,14 +98,27 @@ void UCubismParameterComponent::MultiplyParameterValue(float TargetValue, const 
 	Model->SetParameterValue(Index, CurrentValue);
 }
 
+TObjectPtr<UCubismModelComponent> UCubismParameterComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismParameterComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -133,8 +146,11 @@ void UCubismParameterComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UActorComponent interface

--- a/Source/Live2DCubismFramework/Private/Model/CubismParameterStoreComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Model/CubismParameterStoreComponent.cpp
@@ -85,6 +85,10 @@ void UCubismParameterStoreComponent::LoadParameters()
 {
 	for (const TObjectPtr<UCubismParameterComponent>& Parameter : Model->Parameters)
 	{
+		if (!Parameter)
+		{
+			continue;
+		}
 		if (ParameterValues.Contains(Parameter->Index))
 		{
 			Parameter->SetParameterValue(ParameterValues[Parameter->Index]);
@@ -97,6 +101,10 @@ void UCubismParameterStoreComponent::LoadParameters()
 
 	for (const TObjectPtr<UCubismPartComponent>& Part : Model->Parts)
 	{
+		if (!Part)
+		{
+			continue;
+		}
 		if (PartOpacities.Contains(Part->Index))
 		{
 			Part->SetPartOpacity(PartOpacities[Part->Index]);
@@ -108,14 +116,27 @@ void UCubismParameterStoreComponent::LoadParameters()
 	}
 }
 
+TObjectPtr<UCubismModelComponent> UCubismParameterStoreComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismParameterStoreComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UObject interface
 
@@ -124,17 +145,24 @@ void UCubismParameterStoreComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismParameterStoreComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 {
-	if (Model->ParameterStore == this)
+	if (Model)
 	{
-		Model->ParameterStore = nullptr;
+		if (Model->ParameterStore == this)
+		{
+			Model->ParameterStore = nullptr;
+		}
 	}
+
 
 	Super::OnComponentDestroyed(bDestroyingHierarchy);
 }

--- a/Source/Live2DCubismFramework/Private/Model/CubismPartComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Model/CubismPartComponent.cpp
@@ -51,14 +51,27 @@ void UCubismPartComponent::SetPartOpacity(float TargetOpacity)
 	Model->SetPartOpacity(Index, Opacity);
 }
 
+TObjectPtr<UCubismModelComponent> UCubismPartComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismPartComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -86,8 +99,11 @@ void UCubismPartComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 // End of UActorComponent interface

--- a/Source/Live2DCubismFramework/Private/Motion/CubismMotionComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Motion/CubismMotionComponent.cpp
@@ -115,14 +115,27 @@ void UCubismMotionComponent::StopAllMotions(const bool bForce)
 	}
 }
 
+TObjectPtr<UCubismModelComponent> UCubismMotionComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismMotionComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -145,9 +158,12 @@ void UCubismMotionComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismMotionComponent::OnComponentDestroyed(bool bDestroyingHierarchy)

--- a/Source/Live2DCubismFramework/Private/Physics/CubismPhysicsComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Physics/CubismPhysicsComponent.cpp
@@ -298,14 +298,27 @@ void UCubismPhysicsComponent::UpdateParticlesForStabilization(
 	}
 }
 
+TObjectPtr<UCubismModelComponent> UCubismPhysicsComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismPhysicsComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -328,9 +341,12 @@ void UCubismPhysicsComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismPhysicsComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)

--- a/Source/Live2DCubismFramework/Private/Pose/CubismPoseComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Pose/CubismPoseComponent.cpp
@@ -91,14 +91,27 @@ void UCubismPoseComponent::Setup(UCubismModelComponent* InModel)
 	AddTickPrerequisiteComponent(Model->Motion); // must be updated at first because motions overwrite parameters
 }
 
+TObjectPtr<UCubismModelComponent> UCubismPoseComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismPoseComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -121,9 +134,12 @@ void UCubismPoseComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismPoseComponent::DoFade(float DeltaTime)

--- a/Source/Live2DCubismFramework/Private/Rendering/CubismMaskTextureComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Rendering/CubismMaskTextureComponent.cpp
@@ -22,7 +22,7 @@ UCubismMaskTextureComponent::UCubismMaskTextureComponent()
 	bTickInEditor = true;
 }
 
-void UCubismMaskTextureComponent::AddModel(ACubismModel* Model)
+void UCubismMaskTextureComponent::AddModel(AActor* Model)
 {
 	Models.AddUnique(Model);
 
@@ -37,7 +37,7 @@ void UCubismMaskTextureComponent::AddModel(ACubismModel* Model)
 	bDirty = true;
 }
 
-void UCubismMaskTextureComponent::RemoveModel(ACubismModel* Model)
+void UCubismMaskTextureComponent::RemoveModel(AActor* Model)
 {
 	Models.Remove(Model);
 
@@ -55,11 +55,18 @@ void UCubismMaskTextureComponent::RemoveModel(ACubismModel* Model)
 void UCubismMaskTextureComponent::ResolveMaskLayout()
 {
 	NumMasks = 0;
-	for (const TObjectPtr<ACubismModel>& ModelActor : Models)
+	for (const TObjectPtr<AActor>& ModelActor : Models)
 	{
+		const TObjectPtr<UCubismModelComponent> ModelComp = GetModel(ModelActor);
+
+		if (!ModelComp)
+		{
+			continue;
+		}
+
 		if (IsValid(ModelActor))
 		{
-			NumMasks += ModelActor->Model->Renderer->NumMasks;
+			NumMasks += ModelComp->Renderer->NumMasks;
 		}
 	}
 
@@ -74,14 +81,20 @@ void UCubismMaskTextureComponent::ResolveMaskLayout()
 	AllocateRenderTargets(RenderTargetCount);
 
 	int32 Index = 0;
-	for (const TObjectPtr<ACubismModel>& ModelActor : Models)
+	for (const TObjectPtr<AActor>& ModelActor : Models)
 	{
 		if (!IsValid(ModelActor))
 		{
 			continue;
 		}
+		const TObjectPtr<UCubismModelComponent> ModelComp = GetModel(ModelActor);
 
-		for (const TSharedPtr<FCubismMaskJunction>& Junction : ModelActor->Model->Renderer->Junctions)
+		if (!ModelComp)
+		{
+			continue;
+		}
+
+		for (const TSharedPtr<FCubismMaskJunction>& Junction : ModelComp->Renderer->Junctions)
 		{
 			if (Junction->MaskDrawables.Num() == 0)
 			{
@@ -122,7 +135,7 @@ void UCubismMaskTextureComponent::ResolveMaskLayout()
 				2.0f * Column + 1.0f,
 				2.0f *    Row + 1.0f,
 				0.5f / Resolution,
-				100.0f / ModelActor->Model->GetPixelsPerUnit()
+				100.0f / ModelComp->GetPixelsPerUnit()
 			);
 
 			if (Channel%4 == 0)
@@ -173,6 +186,16 @@ void UCubismMaskTextureComponent::AllocateRenderTargets(const int32 RequiredRTs)
 			RenderTargets.Pop()->MarkAsGarbage();
 		}
 	}
+}
+
+TObjectPtr<UCubismModelComponent> UCubismMaskTextureComponent::GetModel(AActor* Model) 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(Model->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
 }
 
 // UObject interface
@@ -243,16 +266,22 @@ void UCubismMaskTextureComponent::TickComponent(float DeltaTime, ELevelTick Tick
 
 		TArray<FMaskDrawInfo> MaskDrawInfos;
 
-		for (const TObjectPtr<ACubismModel>& ModelActor : Models)
+		for (const TObjectPtr<AActor>& ModelActor : Models)
 		{
 			if (!IsValid(ModelActor))
 			{
 				continue;
 			}
+			const TObjectPtr<UCubismModelComponent> ModelComp = GetModel(ModelActor);
 
-			const TArray<TObjectPtr<UTexture2D>>& Textures = ModelActor->Model->Textures;
+			if (!ModelComp)
+			{
+				continue;
+			}
 
-			for (const TSharedPtr<FCubismMaskJunction>& Junction : ModelActor->Model->Renderer->Junctions)
+			const TArray<TObjectPtr<UTexture2D>>& Textures = ModelComp->Textures;
+
+			for (const TSharedPtr<FCubismMaskJunction>& Junction : ModelComp->Renderer->Junctions)
 			{
 				// If the render target does not match, skip drawing the mask.
 				if (Junction->RenderTarget != RenderTarget)

--- a/Source/Live2DCubismFramework/Private/Rendering/CubismRendererComponent.cpp
+++ b/Source/Live2DCubismFramework/Private/Rendering/CubismRendererComponent.cpp
@@ -26,6 +26,13 @@ UCubismRendererComponent::UCubismRendererComponent()
 	bTickInEditor = true;
 }
 
+void UCubismRendererComponent::BeginPlay() 
+{
+	Super::BeginPlay();
+
+	SpawnMaskTexture();
+}
+
 void UCubismRendererComponent::Setup(UCubismModelComponent* InModel)
 {
 	check(InModel);
@@ -94,10 +101,10 @@ void UCubismRendererComponent::Setup(UCubismModelComponent* InModel)
 	if (MaskTexture)
 	{
 		MaskTexture->MaskTextureComponent->ResolveMaskLayout();
+		AddTickPrerequisiteComponent(MaskTexture->MaskTextureComponent); // must render after mask texture updated
 	}
 
 	AddTickPrerequisiteComponent(Model); // must render after model updated
-	AddTickPrerequisiteComponent(MaskTexture->MaskTextureComponent); // must render after mask texture updated
 }
 
 void UCubismRendererComponent::ApplyRenderOrder()
@@ -140,14 +147,60 @@ void UCubismRendererComponent::ApplyRenderOrder()
 	}
 }
 
+void UCubismRendererComponent::SpawnMaskTexture() 
+{
+	AActor* Owner = GetOwner();
+
+	if (MaskTexture == nullptr)
+	{
+		TArray<AActor*> FoundActors;
+		UGameplayStatics::GetAllActorsOfClass(Owner->GetWorld(), ACubismMaskTexture::StaticClass(), FoundActors);
+		if (FoundActors.Num() == 0)
+		{
+			MaskTexture = Owner->GetWorld()->SpawnActor<ACubismMaskTexture>();
+		}
+		else
+		{
+			MaskTexture = (ACubismMaskTexture*)FoundActors[0];
+		}
+	}
+	else
+	{
+		MaskTexture->MaskTextureComponent->RemoveModel(Owner);
+	}
+	//Should check in case it's spawned in blueprint and the mask texture won't be placed in the blueprint scene
+	if (MaskTexture)
+	{
+#if WITH_EDITOR
+		MaskTexture->SetActorLabel(TEXT("CubismMaskTexture"));
+		MaskTexture->SetFlags(RF_Transactional);
+#endif
+		MaskTexture->MaskTextureComponent->AddModel(Owner);
+	}
+}
+
+
+TObjectPtr<UCubismModelComponent> UCubismRendererComponent::GetModel() 
+{
+	if (TObjectPtr<UCubismModelComponent> ModelComp = Cast<UCubismModelComponent>(GetOwner()->FindComponentByClass<UCubismModelComponent>()))
+	{
+		return ModelComp;
+	}
+
+	return nullptr;
+}
+
 // UObject interface
 void UCubismRendererComponent::PostLoad()
 {
 	Super::PostLoad();
 
-	const ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 #if WITH_EDITOR
@@ -161,7 +214,7 @@ void UCubismRendererComponent::PostEditChangeProperty(FPropertyChangedEvent& Pro
 	{
 		if (MaskTexture)
 		{
-			ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+			AActor* Owner = GetOwner();
 
 			MaskTexture->MaskTextureComponent->AddModel(Owner);
 		}
@@ -184,48 +237,35 @@ void UCubismRendererComponent::OnComponentCreated()
 {
 	Super::OnComponentCreated();
 
-	ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
-
-	if (MaskTexture == nullptr)
+	if (GetWorld()->WorldType != EWorldType::EditorPreview)
 	{
-		TArray<AActor*> FoundActors;
-		UGameplayStatics::GetAllActorsOfClass(Owner->GetWorld(), ACubismMaskTexture::StaticClass(), FoundActors);
-		if (FoundActors.Num() == 0)
-		{
-			MaskTexture = Owner->GetWorld()->SpawnActor<ACubismMaskTexture>();
-			#if WITH_EDITOR
-			MaskTexture->SetActorLabel(TEXT("CubismMaskTexture"));
-			MaskTexture->SetFlags(RF_Transactional);
-			#endif
-		}
-		else
-		{
-			MaskTexture = (ACubismMaskTexture*) FoundActors[0];
-		}
-	}
-	else
-	{
-		MaskTexture->MaskTextureComponent->RemoveModel(Owner);
+		SpawnMaskTexture();
 	}
 
-	MaskTexture->MaskTextureComponent->AddModel(Owner);
+	const TObjectPtr<UCubismModelComponent> ModelComp = GetModel();
 
-	Setup(Owner->Model);
+	if (ModelComp)
+	{
+		Setup(ModelComp);
+	}
 }
 
 void UCubismRendererComponent::OnComponentDestroyed(bool bDestroyingHierarchy)
 {
 	if (MaskTexture)
 	{
-		ACubismModel* Owner = Cast<ACubismModel>(GetOwner());
+		AActor* Owner = GetOwner();
 
 		MaskTexture->MaskTextureComponent->RemoveModel(Owner);
 	}
-
-	if (Model->Renderer == this)
+	if (Model)
 	{
-		Model->Renderer = nullptr;
+		if (Model->Renderer == this)
+		{
+			Model->Renderer = nullptr;
+		}
 	}
+
 
 	Super::OnComponentDestroyed(bDestroyingHierarchy);
 }

--- a/Source/Live2DCubismFramework/Public/Effects/EyeBlink/CubismEyeBlinkComponent.h
+++ b/Source/Live2DCubismFramework/Public/Effects/EyeBlink/CubismEyeBlinkComponent.h
@@ -117,6 +117,7 @@ private:
 	 */
 	UCubismEyeBlinkComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Effects/HarmonicMotion/CubismHarmonicMotionComponent.h
+++ b/Source/Live2DCubismFramework/Public/Effects/HarmonicMotion/CubismHarmonicMotionComponent.h
@@ -43,6 +43,8 @@ private:
 	 */
 	UCubismHarmonicMotionComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Effects/LipSync/CubismLipSyncComponent.h
+++ b/Source/Live2DCubismFramework/Public/Effects/LipSync/CubismLipSyncComponent.h
@@ -109,6 +109,8 @@ private:
 	 */
 	UCubismLipSyncComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Effects/LookAt/CubismLookAtComponent.h
+++ b/Source/Live2DCubismFramework/Public/Effects/LookAt/CubismLookAtComponent.h
@@ -55,6 +55,8 @@ private:
 	 */
 	UCubismLookAtComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Effects/Raycast/CubismRaycastComponent.h
+++ b/Source/Live2DCubismFramework/Public/Effects/Raycast/CubismRaycastComponent.h
@@ -96,6 +96,8 @@ private:
 	 */
 	UCubismRaycastComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Expression/CubismExpressionComponent.h
+++ b/Source/Live2DCubismFramework/Public/Expression/CubismExpressionComponent.h
@@ -54,7 +54,7 @@ struct LIVE2DCUBISMFRAMEWORK_API FCubismExpressionParameterValue
 /**
  * A component to apply the expression motion to the specified parameters of the Cubism model.
  */
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS(Blueprintable)
 class LIVE2DCUBISMFRAMEWORK_API UCubismExpressionComponent : public UActorComponent
 {
 	GENERATED_BODY()
@@ -107,6 +107,8 @@ private:
 	 * @brief The constructor of the component.
 	 */
 	UCubismExpressionComponent();
+
+	TObjectPtr<UCubismModelComponent> GetModel();
 
 	/**
 	 * The model component that the component depends on.

--- a/Source/Live2DCubismFramework/Public/Model/CubismDrawableComponent.h
+++ b/Source/Live2DCubismFramework/Public/Model/CubismDrawableComponent.h
@@ -202,6 +202,8 @@ private:
 	 */
 	UCubismDrawableComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */
@@ -260,6 +262,8 @@ private:
 	void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
 	// End of UObject interface
+
+	
 
 	// UActorComponent interface
 	virtual void OnComponentCreated() override;

--- a/Source/Live2DCubismFramework/Public/Model/CubismModelComponent.h
+++ b/Source/Live2DCubismFramework/Public/Model/CubismModelComponent.h
@@ -28,6 +28,10 @@ class UCubismEyeBlinkComponent;
 class UCubismHarmonicMotionComponent;
 class UCubismLipSyncComponent;
 class UCubismLookAtComponent;
+class UCubismPose3Json;
+class UCubismMotion3Json;
+class UCubismExp3Json;
+class UCubismPhysics3Json;
 
 /**
  * An enumeration for the blend mode of a drawable.
@@ -64,17 +68,30 @@ enum class ECubismParameterType : uint8
 /**
  * A component to control a Live2D Cubism model.
  */
-UCLASS(Blueprintable)
+UCLASS(Blueprintable, meta = (BlueprintSpawnableComponent))
 class LIVE2DCUBISMFRAMEWORK_API UCubismModelComponent : public USceneComponent
 {
 	GENERATED_BODY()
 
 public:
+
 	/**
 	 * The moc asset that contains the model information.
 	 */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Live2D Cubism")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Live2D Cubism")
 	TObjectPtr<UCubismMoc3> Moc;
+
+	/**
+ * The pose asset that contains the pose information.
+ */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Live2D Cubism")
+	TObjectPtr<UCubismPose3Json> PoseJson;
+
+	/**
+* The pose asset that contains the motion information.
+*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Live2D Cubism")
+	TArray<TObjectPtr<UCubismMotion3Json>> MotionJsons;
 
 	/**
 	 * The list of drawable components that consist of the model.
@@ -171,6 +188,18 @@ public:
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Live2D Cubism")
 	TObjectPtr<UCubismUserData3Json> UserDataJson;
+
+	/**
+* The json assets that contain the expression information.
+*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Live2D Cubism")
+	TArray<TObjectPtr<UCubismExp3Json>> ExpressionJsons;
+
+	/**
+* The json assets that contain the physics information.
+*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Live2D Cubism")
+	TObjectPtr<UCubismPhysics3Json> PhysicsJson;
 
 	/**
 	 * The opacity of the model.
@@ -357,7 +386,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Live2D Cubism")
 	UCubismPartComponent* GetPart(const FString PartId);
 
-private:
+public:
 	/**
 	 * @brief The constructor of the component.
 	 */
@@ -540,6 +569,7 @@ private:
 	 */
 	int32 GetDrawableParentPartIndex(const int32 DrawableIndex) const;
 
+	public:
 	/**
 	 * The map from the ID of a drawable to its index.
 	 */
@@ -612,11 +642,14 @@ private:
 	 */
 	void AddParameter(const FString ParameterId);
 
+	public:
 	/**
 	 * The map from the ID of a parameter to its index.
 	 */
 	UPROPERTY()
 	TMap<FString, int32> ParameterIndices;
+
+	private:
 
 	/**
 	 * The list of the IDs of the parameters that are not in the original model.
@@ -661,11 +694,15 @@ private:
 	 */
 	void AddPart(const FString PartId);
 
+	public:
+
 	/**
 	 * The map from the ID of a part to its index.
 	 */
 	UPROPERTY()
 	TMap<FString, int32> PartIndices;
+
+	private:
 
 	/**
 	 * The list of the IDs of the parts that are not in the original model.
@@ -681,6 +718,8 @@ private:
 
 private:
 	friend class UCubismMoc3;
+
+	public:
 
 	/**
 	 * The raw model data.
@@ -699,6 +738,10 @@ public:
 	// UActorComponent interface
 	virtual void OnComponentCreated() override;
 	virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
+
+	void ComponentCleanup();
+
+	void ComponentSetup();
 
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 	// End of UActorComponent interface

--- a/Source/Live2DCubismFramework/Public/Model/CubismParameterComponent.h
+++ b/Source/Live2DCubismFramework/Public/Model/CubismParameterComponent.h
@@ -101,6 +101,9 @@ private:
 	 */
 	UCubismParameterComponent();
 
+
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Model/CubismParameterStoreComponent.h
+++ b/Source/Live2DCubismFramework/Public/Model/CubismParameterStoreComponent.h
@@ -61,6 +61,8 @@ private:
 	 */
 	UCubismParameterStoreComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Model/CubismPartComponent.h
+++ b/Source/Live2DCubismFramework/Public/Model/CubismPartComponent.h
@@ -86,6 +86,8 @@ private:
 	 */
 	UCubismPartComponent();
 
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */

--- a/Source/Live2DCubismFramework/Public/Motion/CubismMotionComponent.h
+++ b/Source/Live2DCubismFramework/Public/Motion/CubismMotionComponent.h
@@ -32,7 +32,7 @@ enum class ECubismMotionPriority : uint8
 /**
  * A component to apply the motion to the specified parameters of the Cubism model.
  */
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS(Blueprintable)
 class LIVE2DCUBISMFRAMEWORK_API UCubismMotionComponent : public UActorComponent
 {
 	GENERATED_BODY()
@@ -121,6 +121,8 @@ private:
 	 * @brief The constructor of the component.
 	 */
 	UCubismMotionComponent();
+
+	TObjectPtr<UCubismModelComponent> GetModel();
 
 	/**
 	 * The model component that the component depends on.

--- a/Source/Live2DCubismFramework/Public/Physics/CubismPhysicsComponent.h
+++ b/Source/Live2DCubismFramework/Public/Physics/CubismPhysicsComponent.h
@@ -17,7 +17,7 @@ class UCubismModelComponent;
 /**
  * A component to apply the physics to the specified parameters of the Cubism model.
  */
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS(Blueprintable)
 class LIVE2DCUBISMFRAMEWORK_API UCubismPhysicsComponent : public UActorComponent
 {
 	GENERATED_BODY()
@@ -67,6 +67,8 @@ private:
 	 * @brief The constructor of the component.
 	 */
 	UCubismPhysicsComponent();
+
+	TObjectPtr<UCubismModelComponent> GetModel();
 
 	/**
 	 * @brief The model component that the component depends on.

--- a/Source/Live2DCubismFramework/Public/Pose/CubismPoseComponent.h
+++ b/Source/Live2DCubismFramework/Public/Pose/CubismPoseComponent.h
@@ -50,7 +50,7 @@ struct FCubismPosePartGroupParameter
 /**
  * A component to apply the pose to the specified parameters of the Cubism model.
  */
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS(Blueprintable)
 class LIVE2DCUBISMFRAMEWORK_API UCubismPoseComponent : public UActorComponent
 {
 	GENERATED_BODY()
@@ -82,6 +82,8 @@ private:
 	 * @brief The constructor of the component.
 	 */
 	UCubismPoseComponent();
+
+	TObjectPtr<UCubismModelComponent> GetModel();
 
 	/**
 	 * @brief Perform the fade operation on the part.

--- a/Source/Live2DCubismFramework/Public/Rendering/CubismMaskTextureComponent.h
+++ b/Source/Live2DCubismFramework/Public/Rendering/CubismMaskTextureComponent.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Model/CubismModelActor.h"
+#include "Model/CubismModelComponent.h"
 #include "Rendering/CubismShaders.h"
 
 #include "CubismMaskTextureComponent.generated.h"
@@ -62,7 +63,7 @@ public:
 	 * The list of ACubismModel instances whose masks are managed by the component.
 	 */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Live2D Cubism")
-	TArray<TObjectPtr<ACubismModel>> Models;
+	TArray<TObjectPtr<AActor>> Models;
 
 	/**
 	 * The list of render targets where the assigned masks are drawn.
@@ -75,14 +76,14 @@ public:
 	 * @param Model The model to add.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Live2D Cubism")
-	void AddModel(ACubismModel* Model);
+	void AddModel(AActor* Model);
 
 	/**
 	 * @brief The function to remove a model from the component.
 	 * @param Model The model to remove.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Live2D Cubism")
-	void RemoveModel(ACubismModel* Model);
+	void RemoveModel(AActor* Model);
 
 	/**
 	 * ResolveMaskLayout
@@ -97,6 +98,8 @@ private:
 	 * @brief The constructor of the component.
 	 */
 	UCubismMaskTextureComponent();
+
+	TObjectPtr<UCubismModelComponent> GetModel(AActor* Model);
 
 	/**
 	 * @brief The function to calculate the optimal level of detail under the current settings.

--- a/Source/Live2DCubismFramework/Public/Rendering/CubismRendererComponent.h
+++ b/Source/Live2DCubismFramework/Public/Rendering/CubismRendererComponent.h
@@ -28,7 +28,7 @@ enum class ECubismRendererSortingOrder : uint8
 /**
  * A component to render Live2D Cubism models.
  */
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS(Blueprintable)
 class LIVE2DCUBISMFRAMEWORK_API UCubismRendererComponent : public UActorComponent
 {
 	GENERATED_BODY()
@@ -96,12 +96,19 @@ private:
 	 */
 	UCubismRendererComponent();
 
+	void SpawnMaskTexture();
+
+	TObjectPtr<UCubismModelComponent> GetModel();
+
 	/**
 	 * The model component that the component depends on.
 	 */
 	TObjectPtr<UCubismModelComponent> Model;
 
 public:	
+
+	virtual void BeginPlay() override;
+
 	// UObject interface
 	virtual void PostLoad() override;
 


### PR DESCRIPTION
Summary: Made many changes to the code that enables it in Blueprint without causing crashes.

Detail:

Made a lot of changes that may or may not correspond to the coding style preference. So just take it or leave it.

I made it so the model component can be added to an actor through the component add. Additionally, I made it flexible to work with any actor type than the model actor.

I also removed some of the components ability to be added through the component add menu. Mainly because I made them be created through the model component instead when you set the corresponding files. Setting the files will create the baseline for the model. You can then also add the other components through the drop down if needed. Made it so they should not crash even if the model component has not been added yet.